### PR TITLE
Deprecate ExtAuthPlugin interface

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -64,7 +64,7 @@ type AuthService interface {
 	Authorize(ctx context.Context, request *AuthorizationRequest) (*AuthorizationResponse, error)
 }
 
-// Deprecated: Prefer ExtAuth Passthrough https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/
+// Deprecated: Prefer Passthrough Auth https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/
 // External authorization plugins must implement this interface
 type ExtAuthPlugin interface {
 	// Gloo will deserialize the external authorization plugin configuration defined on your AuthConfig into the

--- a/api/interface.go
+++ b/api/interface.go
@@ -64,6 +64,7 @@ type AuthService interface {
 	Authorize(ctx context.Context, request *AuthorizationRequest) (*AuthorizationResponse, error)
 }
 
+// Deprecated: Prefer ExtAuth Passthrough https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/
 // External authorization plugins must implement this interface
 type ExtAuthPlugin interface {
 	// Gloo will deserialize the external authorization plugin configuration defined on your AuthConfig into the

--- a/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
+++ b/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
@@ -1,5 +1,5 @@
 changelog:
 - type: FIX
-  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, [ExtAuth Passthrough](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/).
+  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, [Passthrough Auth](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/).
   issueLink: https://github.com/solo-io/solo-projects/issues/6961
   resolvesIssue: false

--- a/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
+++ b/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
@@ -1,5 +1,5 @@
 changelog:
 - type: FIX
-  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, ExtAuth Passthrough: https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/.
+  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, [ExtAuth Passthrough](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/).
   issueLink: https://github.com/solo-io/solo-projects/issues/6961
   resolvesIssue: false

--- a/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
+++ b/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, ExtAuth Passthrough.
+  issueLink: https://github.com/solo-io/solo-projects/issues/6961
+  resolvesIssue: false

--- a/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
+++ b/changelog/v0.2.3/deprecate-ExtAuthPlugin-interface.yaml
@@ -1,5 +1,5 @@
 changelog:
 - type: FIX
-  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, ExtAuth Passthrough.
+  description: Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, ExtAuth Passthrough: https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/.
   issueLink: https://github.com/solo-io/solo-projects/issues/6961
   resolvesIssue: false


### PR DESCRIPTION
Mark ExtAuthPlugin interface as deprecated as we encourage users to use the safer alternative, [Passthrough Auth](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/).