### PR TITLE
Remove the ExtAuthPlugin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# External auth plugins
-This repository contains two public interfaces:
+> **Note:** This repository, despite its name `ext-auth-plugins`, provides core interfaces rather than plugin related interfaces.
+> The ExtAuth plugin support has been deprecated and subsequently removed from the interfaces.
+
+# External Auth Interfaces
+This repository contains the public interface:
 - `AuthService`: is the interface implemented by all [Gloo ext auth implementations](https://gloo.solo.io/gloo_routing/virtual_services/authentication/)
-- `ExtAuthPlugin`: is the interface that needs to be implemented by custom go ext auth plugins
 
 Be sure to check out the docs at gloo.solo.io for more information!

--- a/api/interface.go
+++ b/api/interface.go
@@ -64,54 +64,6 @@ type AuthService interface {
 	Authorize(ctx context.Context, request *AuthorizationRequest) (*AuthorizationResponse, error)
 }
 
-// Deprecated: Prefer Passthrough Auth https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/
-// External authorization plugins must implement this interface
-type ExtAuthPlugin interface {
-	// Gloo will deserialize the external authorization plugin configuration defined on your AuthConfig into the
-	// type returned by this function. The returned type MUST be a pointer.
-	//
-	// For example, given the following plugin configuration:
-	//
-	//  apiVersion: enterprise.gloo.solo.io/v1
-	//  kind: AuthConfig
-	//  metadata:
-	//    name: plugin-auth
-	//    namespace: gloo-system
-	//  spec:
-	//    configs:
-	//    - pluginAuth:
-	//        name: MyAuthPlugin
-	//        config:
-	//          someKey: value-1
-	//          someStruct:
-	//            anotherKey: value-2
-	//
-	// the `NewConfigInstance` function on your `ExtAuthPlugin` implementation should return a pointer to
-	// the following Go struct:
-	//
-	//   type MyPluginConfig struct {
-	//     SomeKey string
-	//     SomeStruct NestedConfig
-	//   }
-	//
-	// where `NestedConfig` is:
-	//
-	//   type NestedConfig struct {
-	//     AnotherKey string
-	//   }
-	//
-	// When Gloo invokes this fun function during plugin initialization, it will pass in a context. The context will
-	// be cancelled whenever Gloo detects a change in the overall auth configuration and consequently re-initializes
-	// all the auth plugins.
-	NewConfigInstance(ctx context.Context) (configInstance interface{}, err error)
-
-	// Returns an authorization service instance.
-	// The input context is the same as the one passed to `NewConfigInstance` and the same considerations apply.
-	// The input configInstance is the same one returned by the `NewConfigInstance` after the plugin configuration has
-	// been deserialized into it.
-	GetAuthService(ctx context.Context, configInstance interface{}) (AuthService, error)
-}
-
 // Minimal OK response
 func AuthorizedResponse() *AuthorizationResponse {
 	return &AuthorizationResponse{

--- a/api/interface_test.go
+++ b/api/interface_test.go
@@ -12,11 +12,8 @@ import (
 var _ = Describe("api has no errors", func() {
 
 	It("can compile everything", func() {
-		var pluginImpl api.ExtAuthPlugin = &pluginImpl{}
-		_, err := pluginImpl.NewConfigInstance(context.Background())
-		Expect(err).NotTo(HaveOccurred())
-
-		svc, err := pluginImpl.GetAuthService(context.Background(), nil)
+		var serviceImpl api.AuthService = &serviceImpl{}
+		svc, err := serviceImpl.Authorize(context.Background(), nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())
 	})
@@ -28,21 +25,12 @@ var _ = Describe("api has no errors", func() {
 		a.SetState("test", 123)
 		Expect(a.GetState("test")).To(BeEquivalentTo(123))
 	})
+
 	It("should not crash when only get state is called", func() {
 		var a api.AuthorizationRequest
 		Expect(a.GetState("test")).To(BeNil())
 	})
 })
-
-type pluginImpl struct{}
-
-func (pluginImpl) NewConfigInstance(ctx context.Context) (configInstance interface{}, err error) {
-	return nil, nil
-}
-
-func (pluginImpl) GetAuthService(ctx context.Context, configInstance interface{}) (api.AuthService, error) {
-	return &serviceImpl{}, nil
-}
 
 type serviceImpl struct{}
 
@@ -51,5 +39,5 @@ func (serviceImpl) Start(ctx context.Context) error {
 }
 
 func (serviceImpl) Authorize(ctx context.Context, request *api.AuthorizationRequest) (*api.AuthorizationResponse, error) {
-	return nil, nil
+	return api.AuthorizedResponse(), nil
 }

--- a/changelog/v0.4.0/remove-ext-auth-plugin.yaml
+++ b/changelog/v0.4.0/remove-ext-auth-plugin.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: BREAKING_CHANGE
+  description: Removed the `ExtAuthPlugin` interface.
+  resolvesIssue: false
+

--- a/changelog/v0.4.0/remove-ext-auth-plugin.yaml
+++ b/changelog/v0.4.0/remove-ext-auth-plugin.yaml
@@ -1,5 +1,6 @@
 changelog:
 - type: BREAKING_CHANGE
   description: Removed the `ExtAuthPlugin` interface.
+  issueLink: https://github.com/solo-io/solo-projects/issues/6962
   resolvesIssue: false
 


### PR DESCRIPTION
The `ExtAuthPlugin` interface is no longer needed after it has been deprecated and late on removed from products.
This repo still serves interfaces which are not plugin related.